### PR TITLE
Replace getAllJava with getAllSource to be able to process non-Java source files

### DIFF
--- a/src/main/java/org/quiltmc/gradle/licenser/task/JavaSourceBasedTask.java
+++ b/src/main/java/org/quiltmc/gradle/licenser/task/JavaSourceBasedTask.java
@@ -36,7 +36,7 @@ public abstract class JavaSourceBasedTask extends DefaultTask {
 	}
 
 	protected void execute(JavaSourceConsumer consumer) {
-		for (var javaDir : this.sourceSet.getAllJava().matching(this.patternFilterable)) {
+		for (var javaDir : this.sourceSet.getAllSource().matching(this.patternFilterable)) {
 			Path sourcePath = javaDir.toPath();
 			consumer.consume(this.getProject(), this.getLogger(), this.getProject().getProjectDir().toPath(), sourcePath);
 		}


### PR DESCRIPTION
closes #1