### PR TITLE
Fix issue with kotlin @file: annotations

### DIFF
--- a/src/main/java/org/quiltmc/gradle/licenser/api/license/LicenseRule.java
+++ b/src/main/java/org/quiltmc/gradle/licenser/api/license/LicenseRule.java
@@ -115,7 +115,7 @@ public class LicenseRule {
 
 		int delimiter = source.indexOf("package");
 		if (path.toString().endsWith(".kt")) {
-			delimiter = source.substring(0, delimiter).contains("@file") ? source.indexOf("@file") : source.indexOf("class");
+			delimiter = source.substring(0, delimiter).contains("@file") ? source.indexOf("@file") : delimiter;
 		}
 		if (delimiter != -1) {
 			// @TODO have a way to specify custom variables?

--- a/src/main/java/org/quiltmc/gradle/licenser/api/license/LicenseRule.java
+++ b/src/main/java/org/quiltmc/gradle/licenser/api/license/LicenseRule.java
@@ -114,6 +114,9 @@ public class LicenseRule {
 		}
 
 		int delimiter = source.indexOf("package");
+		if (path.toString().endsWith(".kt")) {
+			delimiter = source.substring(0, delimiter).contains("@file") ? source.indexOf("@file") : source.indexOf("class");
+		}
 		if (delimiter != -1) {
 			// @TODO have a way to specify custom variables?
 			var map = new HashMap<String, String>();


### PR DESCRIPTION
Previously, the formatter would remove any file-wide annotations when defined in the usual location of before the `package` declaration. This should fix that issue by adding an additional check.