### PR TITLE
Fix version coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a project you need to apply the plugin to your project:
 
 ```groovy
 plugins {
-	id 'org.quiltmc.gradle.licenser' version '1.1.+'
+	id 'org.quiltmc.gradle.licenser' version '1.+'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a project you need to apply the plugin to your project:
 
 ```groovy
 plugins {
-	id 'org.quiltmc.gradle.licenser' version '1.0.+'
+	id 'org.quiltmc.gradle.licenser' version '1.1.+'
 }
 ```
 


### PR DESCRIPTION
The plugin doesn't have any version that satisfies `1.0.+`, but it *does* have versions satisfying `1.1.+`