### PR TITLE
Fix commit lookups on windows

### DIFF
--- a/src/main/java/org/quiltmc/gradle/licenser/api/util/GitUtils.java
+++ b/src/main/java/org/quiltmc/gradle/licenser/api/util/GitUtils.java
@@ -31,6 +31,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
@@ -76,6 +77,10 @@ public final class GitUtils {
 	public static @Nullable RevCommit getLatestCommit(Git git, Path path) {
 		try {
 			var pathStr = path.toString();
+
+			if (!File.separator.equals("/")) {
+				pathStr = pathStr.replace(File.separator, "/");
+			}
 
 			var log = git.log();
 

--- a/src/main/java/org/quiltmc/gradle/licenser/api/util/GitUtils.java
+++ b/src/main/java/org/quiltmc/gradle/licenser/api/util/GitUtils.java
@@ -41,6 +41,16 @@ public final class GitUtils {
 		throw new UnsupportedOperationException("GitUtils only contains static definitions.");
 	}
 
+	private static String standardizePath(Path path) {
+		var pathStr = path.toString();
+
+		if (!File.separator.equals("/")) {
+			pathStr = pathStr.replace(File.separator, "/");
+		}
+
+		return pathStr;
+	}
+
 	private static Git openGit(Project project) throws IOException {
 		return Git.open(project.getRootProject().getProjectDir());
 	}
@@ -76,16 +86,12 @@ public final class GitUtils {
 	 */
 	public static @Nullable RevCommit getLatestCommit(Git git, Path path) {
 		try {
-			var pathStr = path.toString();
-
-			if (!File.separator.equals("/")) {
-				pathStr = pathStr.replace(File.separator, "/");
-			}
+			var pathStr = standardizePath(path);
 
 			var log = git.log();
 
 			if (!pathStr.isEmpty()) {
-				log.addPath(path.toString());
+				log.addPath(pathStr);
 			}
 
 			Iterator<RevCommit> iterator = log
@@ -128,7 +134,7 @@ public final class GitUtils {
 		try (var git = openGit(project)) {
 			Path repoRoot = getRepoRoot(git);
 			path = repoRoot.relativize(path);
-			var pathString = path.toString();
+			var pathString = standardizePath(path);
 
 			var formatter = new DiffFormatter(System.out);
 			formatter.setRepository(git.getRepository());


### PR DESCRIPTION
I think this is the right way to do it? sorry if not, i cant double check on a linux machine

Notably fixes file year lookups always returning the current calendar year, because jgit tries to match against a unix path. Think this might be a git thing? didnt bother to check the spec.
![image](https://user-images.githubusercontent.com/52360088/226216243-02232445-b82d-4d78-b0ff-4aca09f317e3.png)
